### PR TITLE
ci: specify deployment artifact name

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,3 +26,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
+        with:
+          artifact_name: build


### PR DESCRIPTION
The previous commit (0e3e5d2f7e7e99d7b65104aadeee167cc970303e) caused the `build` artifact not to be found while attempting to deploy, so we specify the name of the artifact as `build`.