### PR TITLE
ci: supply github pages base url to hugo build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,8 +8,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-runner
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
       - name: Build
-        run: pnpm build
+        run: pnpm build --baseURL ${{ steps.pages.outputs.base_url }}
       - if: github.ref == 'refs/heads/main'
         name: Upload Artifact
         uses: actions/upload-pages-artifact@v2

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,7 @@
 {{ $data := .Scratch.Get "data" }}
 {{ $googleFontURL := "https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;1,300;1,400&display=swap" }}
 <head>
+  <base href="{{ .Site.BaseURL }}" />
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ .Site.Title }}</title>


### PR DESCRIPTION
Because this project is served with a non-root path and static assets were linked from the root path, these assets would fail to load.

This commit adds the `configure-pages` action before the build and supplies the `base_url` output to the hugo build command.