### PR TITLE
feat: format `ul` in markdown section descriptions

### DIFF
--- a/layouts/partials/resume/section.html
+++ b/layouts/partials/resume/section.html
@@ -46,7 +46,9 @@
         <p class="m-3 hidden text-center italic sm:block">{{ . }}</p>
       {{ end }}
       {{ with .description }}
-        <div class="[&>*]:mt-4 first:[&>*]:mt-0">
+        <div
+          class="[&>*]:mt-4 first:[&>*]:mt-0 [&>ul>li]:pl-2 [&>ul]:mt-0 [&>ul]:list-['-'] [&>ul]:pl-2"
+        >
           {{ . | markdownify }}
         </div>
       {{ end }}


### PR DESCRIPTION
This commit adds support for `ul` rendered by markdown section descriptions by removing padding before `ul` elements and adding a dash (-) before each child `li`.

```yaml
        description: >
          Designed and developed cross-platform mobile application and
          back-end for streaming data from Bluetooth device to remote
          dashboard:


          - Enabled customers to independently maintain and develop their
          applications.


          - Facilitated Stripe partnership through reviewal of submission
          certification.
```

produces
![image](https://github.com/cjshearer/modern-hugo-resume/assets/7173077/4416c71c-0f2b-485a-819f-c10957ef0882)

