### PR TITLE
fix: shift centered layout breakpoint from 'sm to 'md'

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
   {{ partial "head.html" . }}
-  <body class="mx-4 mb-4 mt-8 sm:mx-8">
+  <body class="mx-4 mb-4 mt-8 md:mx-8">
     {{ partial "resume/index.html" $data }}
   </body>
 </html>

--- a/layouts/partials/resume/header.html
+++ b/layouts/partials/resume/header.html
@@ -1,14 +1,14 @@
 <header
-  class="mb-8 flex flex-wrap whitespace-nowrap text-center sm:flex-nowrap"
+  class="mb-8 flex flex-wrap whitespace-nowrap text-center md:flex-nowrap"
 >
-  <div class="mx-auto flex flex-col sm:text-left">
+  <div class="mx-auto flex flex-col md:text-left">
     <p class="text-4xl font-medium">
       {{ .name.first }}
       {{ .name.last }}
     </p>
     <div class="flex flex-wrap gap-2 overflow-hidden text-lg font-light">
       {{ range $titleIndex, $title := .titles }}
-        <p class="mx-auto text-xl font-light sm:ml-0">
+        <p class="mx-auto text-xl font-light md:mx-0">
           {{ $title }}
         </p>
         {{ if ne (add $titleIndex 1) (len $.titles) }}
@@ -17,7 +17,7 @@
       {{ end }}
     </div>
   </div>
-  <div class="grow sm:text-right">
+  <div class="w-full grow md:w-auto md:text-right">
     <ul class="list-none">
       {{ range $socialLink := .links }}
         <li

--- a/layouts/partials/resume/section.html
+++ b/layouts/partials/resume/section.html
@@ -4,9 +4,9 @@
   {{ .title }}
 </p>
 {{ range .entries }}
-  <div class="flex-column mb-12 flex flex-wrap gap-8 sm:flex-nowrap">
+  <div class="flex-column mb-12 flex flex-wrap gap-8 md:flex-nowrap">
     <div
-      class="{{ cond (eq .avatar nil) `sm:w-[15rem]` `w-[15rem]` }} mx-auto min-w-[15rem] sm:mx-0"
+      class="{{ cond (eq .avatar nil) `md:w-[15rem]` `w-[15rem]` }} mx-auto min-w-[15rem] md:mx-0"
     >
       {{ with .avatar }}
         <div class="relative mx-auto h-52 w-52 overflow-hidden rounded-full">
@@ -41,7 +41,7 @@
     </div>
     <div class="flex-grow">
       {{ with .quote }}
-        <p class="m-3 hidden text-center italic sm:block">{{ . }}</p>
+        <p class="m-3 hidden text-center italic md:block">{{ . }}</p>
       {{ end }}
       {{ with .description }}
         <div


### PR DESCRIPTION
This commit shifts the centered layout breakpoint from 'sm' to 'md'.

Previously, the centered layout wasn't triggering early enough, causing a visual imbalance of white space between the left and right of the page, so we make it trigger earlier by replacing all 'sm' breakpoints with 'md'.

![image](https://github.com/cjshearer/modern-hugo-resume/assets/7173077/9ed73a09-2b2e-4adf-9e5e-493ca2fa0340)

