### PR TITLE
fix: hide title separator on desktop wrapping

### DIFF
--- a/layouts/partials/resume/header.html
+++ b/layouts/partials/resume/header.html
@@ -8,7 +8,7 @@
     </p>
     <div class="flex flex-wrap gap-2 overflow-hidden text-lg font-light">
       {{ range $titleIndex, $title := .titles }}
-        <p class="mx-auto text-xl font-light md:mx-0">
+        <p class="mx-auto text-xl font-light md:ml-0">
           {{ $title }}
         </p>
         {{ if ne (add $titleIndex 1) (len $.titles) }}


### PR DESCRIPTION
This commit hides the `hr` separator tag on titles that wrap outside of mobile/tablet layouts (in the desktop layout). This is done by retaining `margin-right: auto` for titles in the desktop layout, thereby pushing the `hr` tag out of view.

Before
![image](https://github.com/cjshearer/modern-hugo-resume/assets/7173077/73c9dba6-38ef-475c-8f44-6c50860844a0)

After
![image](https://github.com/cjshearer/modern-hugo-resume/assets/7173077/f3f4b246-4605-4b27-8166-1dc902935b72)
