### PR TITLE
feat: major layout changes

### DIFF
--- a/data/resume.yaml
+++ b/data/resume.yaml
@@ -1,4 +1,5 @@
 header:
+  avatar: avatar.jpg
   name:
     first: Cody
     last: Shearer
@@ -16,8 +17,7 @@ sections:
   about:
     title: about me
     entries:
-      - avatar: avatar.jpg
-        description: |
+      - description: |
           Hi, I'm Cody, a software developer with a commitment to efficiency
           and excellence. I'm passionate about enhancing productivity through
           platform engineering, refactoring to reduce complexity, or any other
@@ -39,8 +39,7 @@ sections:
   timeline:
     title: timeline
     entries:
-      - name: |
-          [Krumware](https://krum.io)
+      - name: Krumware
         title: Software Developer
         date:
           start: 2021-03-29
@@ -56,8 +55,7 @@ sections:
           Facilitated Stripe partnership through reviewal of submission
           certification.
 
-      - name: |
-          [University of South Carolina](https://sc.edu)
+      - name: University of South Carolina
         date:
           start: 2017-08-17
           end: 2021-05-06
@@ -81,8 +79,7 @@ sections:
           List](https://sc.edu/about/signature_events/awards_day/award_recipients.php?search=Cody%20James%20Shearer#recipients),
           Dean's List
 
-      - name: |
-          [AI and Systems Laboratory](https://pooyanjamshidi.github.io/AISys)
+      - name: AI and Systems Laboratory
         title: Research Assistant
         date:
           start: 2020-08-01
@@ -96,8 +93,7 @@ sections:
 
           Researched relevant works on causal inference and machine learning.
 
-      - name: |
-          [Velocity](https://velocitycloud.com)
+      - name: Velocity
         title: Software Dev Intern
         date:
           start: 2018-06-01

--- a/data/resume.yaml
+++ b/data/resume.yaml
@@ -45,9 +45,6 @@ sections:
         date:
           start: 2021-03-29
           end: null
-        quote: |
-          Building next generation technologies for partners, their people, &
-          the world.
         description: |
           Designed and developed cross-platform mobile application and
           back-end for streaming data from Bluetooth device to remote
@@ -68,9 +65,6 @@ sections:
           [BS Computer Science](pdf/usc-diploma.pdf)
         subtitle: Minor Mathematics
         icon: fa fa-file-pdf
-        quote: |
-          Founded in 1801, Columbia is the flagship research institution of the
-          USC System.
         description: |
           My time at USC has been fundamental in my development as problem
           solver and developer. My favorite courses have been Artificial
@@ -93,9 +87,6 @@ sections:
         date:
           start: 2020-08-01
           end: 2021-04-01
-        quote: |
-          Investigating open problems at the intersection of artificial
-          intelligence, machine learning, and computer systems.
         description: |
           Analyzed cross-platform performance behavior of deep-learning
           recommender system in collaboration with Columbia University.
@@ -111,8 +102,6 @@ sections:
         date:
           start: 2018-06-01
           end: 2018-08-01
-        quote: |
-          Cloud Technology Provider
         description: |
           Created AWS storage primitive abstracting cloud complexity for high
           level orchestration.

--- a/layouts/partials/resume/header.html
+++ b/layouts/partials/resume/header.html
@@ -1,7 +1,7 @@
 <header
   class="mb-8 flex flex-wrap whitespace-nowrap text-center md:flex-nowrap"
 >
-  <div class="mx-auto flex flex-col md:text-left">
+  <div class="mx-auto flex flex-col md:ml-0 md:text-left">
     <p class="text-4xl font-medium">
       {{ .name.first }}
       {{ .name.last }}
@@ -17,25 +17,34 @@
       {{ end }}
     </div>
   </div>
-  <div class="w-full grow md:w-auto md:text-right">
-    <ul class="list-none">
-      {{ range $socialLink := .links }}
-        <li
-          class="inline-block first:pr-1 last:pl-1 [&:not(:first-child):not(:last-child)]:px-1"
-        >
-          <a
-            class="group relative table-cell h-[3.75rem] w-[3.75rem] rounded-full text-center before:absolute before:left-0 before:top-0 before:-z-10 before:h-full before:w-full before:scale-90 before:rounded-[inherit] before:transition-[transform_box-shadow] before:duration-[250ms] before:[box-shadow:inset_0_0_0_3rem_currentColor] hover:before:scale-100 hover:before:[box-shadow:inset_0_0_0_0.125rem_currentColor]"
-            href="{{ .link }}"
-          >
-            <div
-              class="flex h-full w-full items-center justify-center text-neutral-800 group-hover:text-inherit"
+  <div class="flex w-full flex-col gap-2 md:w-auto md:text-right">
+    <div class="flex h-[3.75rem] justify-center">
+      <ul class="flex list-none justify-center gap-2">
+        {{ range $socialLink := .links }}
+          <li class="aspect-square">
+            <a
+              class="group relative block h-full w-full rounded-full text-center before:absolute before:left-0 before:top-0 before:-z-10 before:h-full before:w-full before:scale-90 before:rounded-[inherit] before:transition-[transform_box-shadow] before:duration-[250ms] before:[box-shadow:inset_0_0_0_3rem_currentColor] hover:before:scale-100 hover:before:[box-shadow:inset_0_0_0_0.125rem_currentColor]"
+              href="{{ .link }}"
             >
-              {{ partial "svg.html" (dict "src" .svg "size" "2.15rem") }}
+              <div
+                class="flex h-full w-full items-center justify-center text-neutral-800 group-hover:text-inherit"
+              >
+                {{ partial "svg.html" (dict "src" .svg "size" "2.15rem") }}
+              </div>
+            </a>
+          </li>
+        {{ end }}
+        {{ with .avatar }}
+          <li class="relative aspect-square overflow-hidden rounded-full">
+            <div
+              class="after:absolute after:top-0 after:block after:h-full after:w-full after:rounded-full after:[box-shadow:inset_0_0_20px_0_theme(colors.neutral.500)]"
+            >
+              {{ partial "imgh.html" (dict "src" .) }}
             </div>
-          </a>
-        </li>
-      {{ end }}
-    </ul>
+          </li>
+        {{ end }}
+      </ul>
+    </div>
     <a aria-label="{{ .name.first }}'s email" href="mailto:{{ .email }}">
       {{ .email }}
     </a>

--- a/layouts/partials/resume/section.html
+++ b/layouts/partials/resume/section.html
@@ -42,9 +42,6 @@
       {{ end }}
     </div>
     <div class="flex-grow">
-      {{ with .quote }}
-        <p class="m-3 hidden text-center italic md:block">{{ . }}</p>
-      {{ end }}
       {{ with .description }}
         <div class="prose prose-invert">
           {{ . | markdownify }}

--- a/layouts/partials/resume/section.html
+++ b/layouts/partials/resume/section.html
@@ -1,52 +1,41 @@
-<p
-  class="mb-8 border-b-2 border-dashed border-neutral-400 pb-2 text-center text-3xl font-light capitalize"
->
-  {{ .title }}
-</p>
-{{ range .entries }}
-  <div
-    class="flex-column mb-12 flex break-inside-avoid flex-wrap gap-8 md:flex-nowrap"
+{{ $dateFormat := "2006" }}
+<section>
+  <h1
+    class="mb-8 border-b-2 border-dashed border-neutral-400 pb-2 text-center text-3xl font-light capitalize"
   >
-    <div
-      class="{{ cond (eq .avatar nil) `md:w-[15rem]` `w-[15rem]` }} mx-auto min-w-[15rem] md:mx-0"
-    >
-      {{ with .avatar }}
-        <div class="relative mx-auto h-52 w-52 overflow-hidden rounded-full">
-          <div
-            class="after:absolute after:top-0 after:block after:h-full after:w-full after:rounded-full after:[box-shadow:inset_0_0_20px_0_theme(colors.neutral.500)]"
-          >
-            {{ partial "imgh.html" (dict "src" .) }}
-          </div>
-        </div>
-      {{ end }}
-      {{ with .title }}
-        <p class="prose prose-invert text-center text-2xl font-medium">
-          {{ . | markdownify }}
-        </p>
-      {{ end }}
-      {{ with .name }}
-        <p class="prose prose-invert text-center">
-          {{ . | markdownify }}
-        </p>
-      {{ end }}
-      {{ with .date }}
-        <p class="text-center">
-          {{ time.Format "Jan 2006" .start }} -
-          {{ if .end }}
-            {{ time.Format "Jan 2006" .end }}
-          {{ else }}
-            present
-            {{ " " }}
+    {{ .title }}
+  </h1>
+  {{ range .entries }}
+    {{ $startDate := "" }}
+    {{ $endDate := "present" }}
+    {{ with .date }}
+      {{ $startDate = time.Format $dateFormat .start }}
+      {{ with .end }}{{ $endDate = time.Format $dateFormat . }}{{ end }}
+    {{ end }}
+    <section class="mb-12 break-inside-avoid gap-2 md:grid md:grid-cols-12">
+      <div class="col-span-11">
+        <div class="flex justify-between">
+          {{ with .name }}
+            <h2 class="text-2xl font-medium">{{ . }}</h2>
           {{ end }}
-        </p>
-      {{ end }}
-    </div>
-    <div class="flex-grow">
-      {{ with .description }}
-        <div class="prose prose-invert">
-          {{ . | markdownify }}
+          {{ with .date }}
+            <p class="md:hidden">{{ $startDate }} - {{ $endDate }}</p>
+          {{ end }}
+        </div>
+        {{ with .title }}
+          <h3 class="text-lg">{{ . | markdownify }}</h3>
+        {{ end }}
+        {{ with .description }}
+          <div class="prose prose-invert">{{ . | markdownify }}</div>
+        {{ end }}
+      </div>
+      {{ with .date }}
+        <div class="hidden text-center md:block">
+          <p>{{ $startDate }}</p>
+          <p>|</p>
+          <p>{{ $endDate }}</p>
         </div>
       {{ end }}
-    </div>
-  </div>
-{{ end }}
+    </section>
+  {{ end }}
+</section>


### PR DESCRIPTION
This PR makes a dramatic change to the layout of sections, moving the avatar from the "About Me" section to the right of the social links in the header. It also joins a section's `title` and `name` with its `description`, making the `date` display to the right of each section.

The purpose of this change is to make better use of the available whitespace.

| before | after |
| --- | --- |
| ![before](https://github.com/cjshearer/modern-hugo-resume/assets/7173077/7dec59cd-b07c-4ea2-be5b-60a9cb3dd7a6) | ![after](https://github.com/cjshearer/modern-hugo-resume/assets/7173077/f7454d1c-bc76-4e91-9cb3-a338061e341d) |
