### PR TITLE
fix: don't wrap date

### DIFF
--- a/layouts/partials/resume/section.html
+++ b/layouts/partials/resume/section.html
@@ -14,12 +14,15 @@
     {{ end }}
     <section class="mb-12 break-inside-avoid gap-2 md:grid md:grid-cols-12">
       <div class="col-span-11">
-        <div class="flex justify-between">
+        <div class="flex justify-between gap-2">
           {{ with .name }}
             <h2 class="text-2xl font-medium">{{ . }}</h2>
           {{ end }}
           {{ with .date }}
-            <p class="md:hidden">{{ $startDate }} - {{ $endDate }}</p>
+            <p class="whitespace-nowrap md:hidden">
+              {{ $startDate }} -
+              {{ $endDate }}
+            </p>
           {{ end }}
         </div>
         {{ with .title }}


### PR DESCRIPTION
The date to the right of each timeline/section entry would wrap on mobile displays, so we add `whitespace-nowrap` to prevent this.