### PR TITLE
fix: preserve `data-open` css selectors

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,5 +1,4 @@
-{{ $styles := resources.Get "css/main.css" }}
-{{ $styles := $styles | postCSS }}
+{{ $styles := resources.Get "css/main.css" | resources.PostCSS }}
 {{ if hugo.IsProduction }}
   {{- with $styles | minify | fingerprint | resources.PostProcess -}}
 		<style>{{- .Content | safeCSS }}</style>

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -15,7 +15,11 @@ if (process.env.HUGO_ENVIRONMENT === "production") {
     /** @type {import('@fullhuman/postcss-purgecss').UserDefinedOptions} */
     "@fullhuman/postcss-purgecss": {
       content: ["./hugo_stats.json"],
-      defaultExtractor: (content) => JSON.parse(content).htmlElements,
+      dynamicAttributes: ["data-open"],
+      defaultExtractor: (content) => {
+        const els = JSON.parse(content).htmlElements;
+        return Object.values(els).reduce((acc, val) => acc.concat(val), []);
+      },
       variables: true,
     },
   });


### PR DESCRIPTION
`PurgeCSS` was removing styles using the `data-open` attribute. This commit adds that attribute to a list of dynamic attributes to be preserved.

resolves #18