### PR TITLE
fix: remove `-webkit-tap-highlight-color`

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -6,6 +6,7 @@
   html {
     @apply bg-neutral-800 text-neutral-200;
 
+    -webkit-tap-highlight-color: transparent;
     font-family: Roboto, sans-serif;
   }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2,26 +2,24 @@
 @tailwind components;
 @tailwind utilities;
 
-@media screen {
+@layer base {
+  html {
+    @apply bg-neutral-800 text-neutral-200;
+
+    font-family: Roboto, sans-serif;
+  }
+
   a {
-    text-decoration: underline;
+    @apply underline decoration-1 underline-offset-4 hover:text-neutral-100;
+  }
+
+  code {
+    @apply whitespace-nowrap rounded-md border border-neutral-500 bg-neutral-900 px-1;
   }
 }
 
-html {
-  @apply bg-neutral-800;
-}
-
-body {
-  font-family: Roboto, sans-serif;
-
-  @apply text-neutral-200;
-}
-
-a {
-  @apply decoration-1 underline-offset-4 hover:text-neutral-100;
-}
-
-code {
-  @apply whitespace-nowrap rounded-md border border-neutral-500 bg-neutral-900 px-1 text-neutral-200;
+@media print {
+  a {
+    text-decoration: none;
+  }
 }


### PR DESCRIPTION
Some browsers use the `-webkit-tap-highlight-color` to set the color of
the highlight that appears over a link while it's being tapped. This
isn't desired, as we have, or plan to have interactive elements respond
visually to interactions.