### PR TITLE
fix!: allow URIs without authority component

### DIFF
--- a/data/resume.yaml
+++ b/data/resume.yaml
@@ -2,14 +2,11 @@ avatar: avatar.jpg
 website: cjshearer.dev
 links:
   - svg: node_modules/@fortawesome/fontawesome-free/svgs/brands/github
-    link: github.com/cjshearer
-    protocol: https
+    url: https://github.com/cjshearer
   - svg: node_modules/@fortawesome/fontawesome-free/svgs/brands/linkedin
-    link: linkedin.com/in/cjshearer
-    protocol: https
+    url: https://linkedin.com/in/cjshearer
   - svg: node_modules/@fortawesome/fontawesome-free/svgs/solid/envelope
-    link: cjshearer@live.com
-    protocol: mailto
+    url: mailto:cjshearer@live.com
 name:
   first: Cody
   last: Shearer

--- a/layouts/partials/resume/drawer.html
+++ b/layouts/partials/resume/drawer.html
@@ -19,8 +19,9 @@
       <ul aria-label="social links">
         {{ range . }}
           <li>
-            <a href="{{ .protocol }}://{{ .link }}" class="text-sm">
-              {{ .link }}
+            <a href="{{ .url }}" class="text-sm">
+              {{ $url := .url | urls.Parse }}
+              {{ $url.Hostname }}{{ $url.RequestURI }}
             </a>
           </li>
         {{ end }}

--- a/layouts/partials/resume/header.html
+++ b/layouts/partials/resume/header.html
@@ -15,7 +15,7 @@
       <li class="aspect-square">
         <a
           class="group relative block h-full w-full rounded-full text-center before:absolute before:left-0 before:top-0 before:-z-10 before:h-full before:w-full before:scale-90 before:rounded-[inherit] before:transition-[transform_box-shadow] before:duration-[250ms] before:[box-shadow:inset_0_0_0_3rem_currentColor] hover:before:scale-100 hover:before:[box-shadow:inset_0_0_0_0.125rem_currentColor]"
-          href="{{ .protocol }}://{{ .link }}"
+          href="{{ .url }}"
         >
           <div
             class="flex h-full w-full items-center justify-center text-neutral-800 group-hover:text-inherit"


### PR DESCRIPTION
Previously, links were naively required to be provided as a so-called `protocol` and `link` pair, where `protocol` was a `scheme` and `link` referred the `authority` and `path`. The purpose of this format was to provide a simple way to display urls without the `scheme`, while including the scheme in `href`s by constructing them with `{{protocol}}://{{link}}`.

This made the implicit assumption that all URIs had an authority component, which was shown to be untrue by the presence of a `mailto` link, which would incorrectly have a `//` placed between the `scheme` (mailto) and the `path` (cjshearer@live.com).

This commit changes the format expected for urls provided in `resume.yaml` back to a single string. Where the `scheme` is not desired for display, the builtin URL parsing is used to assist removing it.

resolves #19