### PR TITLE
Update plaintext layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-_A minimal static resume builder; inspired by [sproogen's modern-resume-theme](https://github.com/sproogen/modern-resume-theme) and [mnjul's html-resume](https://github.com/mnjul/html-resume).Powered by Hugo, Tailwind CSS, and GitHub Pages._
+_A minimal static resume builder; inspired by [sproogen's modern-resume-theme](https://github.com/sproogen/modern-resume-theme) and [mnjul's html-resume](https://github.com/mnjul/html-resume). Powered by Hugo, Tailwind CSS, and GitHub Pages._
 
 _Host your own resume on GitHub for free!_
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -111,7 +111,7 @@ Project Highlights:
 
 {{<resume/entry name="BS Computer Science" affiliation="University of South Carolina" startdate="2017-08-17" enddate="2021-05-06">}}
 
-- Graduated [Magna cum Laude](pdf/usc-diploma.pdf) with a mathematics minor
+- Graduated [*magna cum laude*](pdf/usc-diploma.pdf) with a mathematics minor
 - Achieved [Outstanding Senior Award](https://sc.edu/about/offices_and_divisions/leadership_and_service_center/awards_and_recognition/senior-awards/index.php) and the [Palmetto Fellows Scholarship](https://sc.edu/about/offices_and_divisions/financial_aid/scholarships/scholarships_for_sc_residents/palmetto_fellows/index.php)
 - Earned honors including President's List, Dean's List, and [Phi Beta Kappa](https://www.pbk.org/About)
 - Served as President and Treasurer of the Carolina Movement Club (*parkour!*)

--- a/layouts/_default/_markup/render-heading.txt
+++ b/layouts/_default/_markup/render-heading.txt
@@ -1,7 +1,7 @@
 {{- if eq .Level 2 -}}
   -------------------------------------------------------------------------------------------
+{{ .Text | strings.ToUpper -}}
 {{- else -}}
   TODO: implement me if this shows up
 {{- end }}
-{{ .Text }}
 

--- a/layouts/index.txt
+++ b/layouts/index.txt
@@ -1,8 +1,8 @@
 {{ .Params.name }}
--------------------------------------------------------------------------------------------
-Summary
-
 {{ .Params.summary }}
+-------------------------------------------------------------------------------------------
+SKILLS
+
 {{ range .Params.Skills }}
   {{- range $category, $items := . }}
     {{- $category | strings.FirstUpper }}: {{ delimit $items ", " }}
@@ -10,6 +10,7 @@ Summary
 {{ end }}
 {{ .Content -}}
 -------------------------------------------------------------------------------------------
+LINKS
 
 {{ range .Params.links }}
   {{- .name}}: {{ partial "plainTextURI.html" .url }}


### PR DESCRIPTION
Section headers have been made UPPERCASE as that
is a common convention for resumes that ATS
systems may look for.

The summary has been moved directly under the
name, and the section previously named "summary"
is now more aptly named "skills".

The section containing links to various other
platforms is now named "links".