### PR TITLE
refactor!: move favicon site param to page param

### DIFF
--- a/assets/images/faviconEmojiTemplate.svg
+++ b/assets/images/faviconEmojiTemplate.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <text y=".9em" font-size="90">
-    {{ .Site.Params.faviconEmoji }}
-  </text>
-</svg>

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,6 +4,7 @@ dateformat:
   short: Jan. 2006
   long: January 2006
 title: Resume
+faviconText: 💼
 skills:
   - languages:
       - TypeScript

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -41,5 +41,3 @@ outputFormats:
     mediaType: text/plain
     baseName: index
     isPlainText: true
-Params:
-  faviconEmoji: 💼

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,8 +10,16 @@
   <link rel="preload" href="{{ $googleFontURL }}" as="style" />
   <link rel="stylesheet" href="{{ $googleFontURL }}" />
   <link rel="canonical" href="{{ .Permalink }}" />
-  {{ if .Site.Params.faviconEmoji }}
-    {{ $favicon := resources.Get "images/faviconEmojiTemplate.svg" | resources.Minify | resources.ExecuteAsTemplate "images/favicon.svg" . }}
+  {{ with .Page.Params.faviconText }}
+    {{ $faviconString := print
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">`
+      `<text y="0.9em" font-size="80">` . `</text>
+      </svg>`
+    }}
+    {{ $favicon := $faviconString
+      | resources.FromString (print "images/" (md5 $faviconString) ".svg")
+      | resources.Minify
+    }}
     <link
       rel="icon"
       href="data:{{ $favicon.MediaType.Type }};base64,{{ $favicon.Content | base64Encode }}"


### PR DESCRIPTION
This commit moves and renames `.Site.params.faviconEmojiTemplate` to
`.Page.params.faviconText`. This both clarifies that the parameter accepts any text - not necessarily an emoji, as well as furthering a wider effort to make this page fully configurable from one location.

* refactor: move favicon template to head partial

We move the favicon svg template to the head partial, since it will never be used anywhere else.

* fix: bust favicon cache during development

While using `hugo server`, the first generated favicon would cached and used for the duration. We now name the generated resource with its md5 hash to prevent this.