### PR TITLE
build: fix unstable hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Clone your forked repository and modify it as follows:
 
 ### 6. Rename your Hugo Module and Import Theme
 
-Rename your module and remove the replacement directive to change `modern-hugo-resume` from a local to a remote dependency:
+Rename your module and remove the replacement directive to change `modern-hugo-resume` from a local to a remote dependency, then fetch the latest version with `hugo mod get -u github.com/cjshearer/modern-hugo-resume`.
 
 ```diff
 // go.mod (originally from `exampleSite/go.mod`)
@@ -93,8 +93,20 @@ See [`cjshearer.dev/flake.nix`](https://github.com/cjshearer/cjshearer.dev/blob/
 - inherit (finalAttrs) src sourceRoot;
 + inherit (finalAttrs) src;
 ...
+- # We remove our vendored hugo module to avoid updating the outputHash every time
+- # we change modern-hugo-resume. If only Go supported partial vendoring...
+- rm -rf _vendor/github.com/cjshearer/modern-hugo-resume
+...
 - outputHash = "sha256-someOldHash=
 + outputHash = "sha256-someNewHash=
+...
+- # We substitute our vendored hugo module we removed with a symlink to the root.
+- cp -rs ${hugoVendor} _vendor
++ ln -s ${hugoVendor} _vendor
+- chmod +w _vendor/github.com/cjshearer
+- rm -rf _vendor/github.com/cjshearer/modern-hugo-resume
+- ln -s $src _vendor/github.com/cjshearer/modern-hugo-resume
+...
 ```
 
 ### 8. Commit and Push
@@ -111,7 +123,7 @@ git push
 
 ### Requirements
 
-These can be installed manually, or automatically with [nix](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#the-determinate-nix-installer) by running `nix develop`:
+These can be installed manually, or automatically with [nix](https://nixos.org/download/) by running `nix develop`:
 
 1. Install [`hugo`](https://gohugo.io/installation/) >= 1.28.0+extended.
 2. Install [`go`](https://go.dev/dl/) >= 1.22.3.

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -8,5 +8,5 @@ replace github.com/cjshearer/modern-hugo-resume => ../
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect
-	github.com/cjshearer/modern-hugo-resume v0.0.0-20240625183116-2a701eb5eb00 // indirect
+	github.com/cjshearer/modern-hugo-resume v0.0.0 // indirect
 )

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -23,6 +23,13 @@ title = true
 [[module.imports]]
 path = "github.com/cjshearer/modern-hugo-resume"
 
+[[module.imports]]
+path = "github.com/FortAwesome/Font-Awesome"
+
+[[module.imports.mounts]]
+source = "svgs"
+target = "assets/svgs"
+
 [[module.mounts]]
 disableWatch = true
 source = "hugo_stats.json"

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,9 @@
                 '';
 
                 installPhase = ''
+                  # We remove our vendored hugo module to avoid updating the outputHash every time
+                  # we change modern-hugo-resume. If only Go supported partial vendoring...
+                  rm -rf _vendor/github.com/cjshearer/modern-hugo-resume
                   cp -r _vendor $out
                 '';
 
@@ -77,11 +80,16 @@
                 # 1. Invalidate the current hash (change any character between "sha256-" and "=")
                 # 2. Run `nix build` or push to GitHub (it will fail and provide the new hash)
                 # 3. Substitute the new hash (`nix build` should now work)
-                outputHash = "sha256-wBVHv3PNdaDjeXd7E3DfnXRddM9bfWPTp6ROQApPjsc=";
+                outputHash = "sha256-KzscxZKLTIxydtTV+Qn7NSB2X4irpKF1i/4RcbA4j/k=";
               };
             in
             ''
-              ln -s ${hugoVendor} _vendor
+              # We substitute our vendored hugo module we removed with a symlink to the root.
+              cp -rs ${hugoVendor} _vendor
+              chmod +w _vendor/github.com/cjshearer
+              rm -rf _vendor/github.com/cjshearer/modern-hugo-resume
+              ln -s $src _vendor/github.com/cjshearer/modern-hugo-resume
+
               hugo --minify -d $out
             '';
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/cjshearer/modern-hugo-resume
 
 go 1.22.3
-
-require github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 h1:2aWEKCRLqQ9nPyXaz4/IYtRrDr3PzEiX0DUSUr2/EDs=
-github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=

--- a/hugo.toml
+++ b/hugo.toml
@@ -13,10 +13,3 @@ name = "Cody Shearer"
 [module.hugoVersion]
 extended = true
 min = "0.116.3"
-
-[[module.imports]]
-path = "github.com/FortAwesome/Font-Awesome"
-
-[[module.imports.mounts]]
-source = "svgs"
-target = "assets/svgs"


### PR DESCRIPTION
Because the exampleSite's vendored dependencies include the `modern-hugo-resume` module defined in the root of our repo, its hash would need to be changed every time we updated the module.

This was likely the cause of the site failing to build/deploy from https://github.com/cjshearer/modern-hugo-resume/pull/52.

We also remove the font awesome module as a dependency of our module, making it only be a dependency of the exampleSite.