### PR TITLE
build: fix missing SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,52 +61,46 @@ Clone your forked repository and modify it as follows:
 
 ### 6. Rename your Hugo Module and Import Theme
 
-Rename your module and remove the replacement directive to change `modern-hugo-resume` from a local to a remote dependency, then fetch the latest version with `hugo mod get -u github.com/cjshearer/modern-hugo-resume`.
+Rename your module, remove the `noVendor` and `replacements` configs, then import the theme from GitHub with `hugo mod get -u github.com/cjshearer/modern-hugo-resume`.
 
 ```diff
 // go.mod (originally from `exampleSite/go.mod`)
 - module github.com/cjshearer/modern-hugo-resume/exampleSite
 + module github.com/<your username>/<your repo>
 
-- // We use this for local development. Remove it if you're
-- // extracting the exampleSite to your own repository.
-- replace github.com/cjshearer/modern-hugo-resume => ../
+# hugo.toml (originally from `exampleSite/hugo.toml`)
+- [module]
+- noVendor = "github.com/cjshearer/modern-hugo-resume"
+- replacements = "github.com/cjshearer/modern-hugo-resume -> ../.."
 ```
 
 ### 7. Update Build Path, Name, and Dependency Hash
 
 GitHub Actions is configured to build the site using Nix. Now that your site is built from the root directory (not `exampleSite`), you should update its `pname` and remove the custom `sourceRoot`.
 
-Nix also requires the expected hash of downloaded dependencies, which now includes `modern-hugo-resume`, so you will need to update this hash. Follow the instructions above `outputHash` in [`flake.nix`](./flake.nix).
-
-See [`cjshearer.dev/flake.nix`](https://github.com/cjshearer/cjshearer.dev/blob/9b49eaef33ed9fb4d8726f6578085d76145c3d1a/flake.nix) for reference.
+As Nix requires the expected hash of downloaded dependencies, which now includes `modern-hugo-resume`, you will need to update this hash. Follow the instructions above `outputHash` in [`flake.nix`](./flake.nix).
 
 ```diff
 # flake.nix
 ...
+
 - pname = "modern-hugo-resume-exampleSite"
 + pname = "<your username>.github.io"
+
 ...
+
 - sourceRoot = "${finalAttrs.src.name}/exampleSite";
+
 ...
+
   name = "${finalAttrs.pname}-hugoVendor";
 - inherit (finalAttrs) src sourceRoot;
 + inherit (finalAttrs) src;
+
 ...
-- # We remove our vendored hugo module to avoid updating the outputHash every time
-- # we change modern-hugo-resume. If only Go supported partial vendoring...
-- rm -rf _vendor/github.com/cjshearer/modern-hugo-resume
-...
+
 - outputHash = "sha256-someOldHash=
 + outputHash = "sha256-someNewHash=
-...
-- # We substitute our vendored hugo module we removed with a symlink to the root.
-- cp -rs ${hugoVendor} _vendor
-+ ln -s ${hugoVendor} _vendor
-- chmod +w _vendor/github.com/cjshearer
-- rm -rf _vendor/github.com/cjshearer/modern-hugo-resume
-- ln -s $src _vendor/github.com/cjshearer/modern-hugo-resume
-...
 ```
 
 ### 8. Commit and Push

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -2,11 +2,5 @@ module github.com/cjshearer/modern-hugo-resume/exampleSite
 
 go 1.22.3
 
-// We use this for local development. Remove it if you're
-// extracting the exampleSite to your own repository.
-replace github.com/cjshearer/modern-hugo-resume => ../
+require github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect
 
-require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect
-	github.com/cjshearer/modern-hugo-resume v0.0.0 // indirect
-)

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -20,6 +20,10 @@ wrapStandAloneImageWithinParagraph = false
 block = true
 title = true
 
+[module]
+noVendor = "github.com/cjshearer/modern-hugo-resume"
+replacements = "github.com/cjshearer/modern-hugo-resume -> ../.."
+
 [[module.imports]]
 path = "github.com/cjshearer/modern-hugo-resume"
 

--- a/flake.nix
+++ b/flake.nix
@@ -68,9 +68,6 @@
                 '';
 
                 installPhase = ''
-                  # We remove our vendored hugo module to avoid updating the outputHash every time
-                  # we change modern-hugo-resume. If only Go supported partial vendoring...
-                  rm -rf _vendor/github.com/cjshearer/modern-hugo-resume
                   cp -r _vendor $out
                 '';
 
@@ -80,15 +77,11 @@
                 # 1. Invalidate the current hash (change any character between "sha256-" and "=")
                 # 2. Run `nix build` or push to GitHub (it will fail and provide the new hash)
                 # 3. Substitute the new hash (`nix build` should now work)
-                outputHash = "sha256-KzscxZKLTIxydtTV+Qn7NSB2X4irpKF1i/4RcbA4j/k=";
+                outputHash = "sha256-mFnxMxPDojDfxKDZE8xGopHYFnUi1/L7rjGsealysao=";
               };
             in
             ''
-              # We substitute our vendored hugo module we removed with a symlink to the root.
-              cp -rs ${hugoVendor} _vendor
-              chmod +w _vendor/github.com/cjshearer
-              rm -rf _vendor/github.com/cjshearer/modern-hugo-resume
-              ln -s $src _vendor/github.com/cjshearer/modern-hugo-resume
+              ln -s ${hugoVendor} _vendor
 
               hugo --minify -d $out
             '';


### PR DESCRIPTION
The previous PR (#53) broke SVGs by symlinking the vendored dependencies, which is no longer supported by hugo (gohugoio/hugo#11556).

We fix this by using hugo's `noVendor` and `replacements` configuration options supplied in `hugo.toml`, rather than the goofy workaround we made in (#53).