### PR TITLE
fix: footer positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # modern-hugo-resume
 
-A responsive, minimal, print-friendly resume builder. Powered by Hugo, Tailwind CSS, Nix, and GitHub Pages.
+A responsive, minimal, print-friendly resume builder. Powered by Hugo, Tailwind CSS, Paged.js, Nix, and GitHub Pages.
 
 _Host your own resume on GitHub for free!_
 

--- a/assets/css/modern-hugo-resume.css
+++ b/assets/css/modern-hugo-resume.css
@@ -9,7 +9,6 @@
     margin-left: auto;
     margin-right: auto;
     max-width: var(--page-width);
-    /* css padding emulates PDF margins */
     padding: var(--page-margin);
 
     @media not all and (min-width: theme("screens.sm")) {
@@ -21,16 +20,8 @@
     }
   }
 
-  main {
-    margin-bottom: var(--page-margin);
-
-    & > *:first-child {
-      margin-top: 0;
-    }
-
-    @media print {
-      margin-bottom: 0;
-    }
+  main > *:first-child {
+    margin-top: 0;
   }
 
   :root {
@@ -61,7 +52,7 @@
     margin-bottom: theme("margin.4");
     margin-top: theme("margin.6");
     line-height: 1.25;
-    break-after: avoid-page;
+    break-after: avoid;
   }
 
   h1 {
@@ -93,7 +84,7 @@
   ul,
   ol {
     margin-bottom: theme("margin.4");
-    break-inside: avoid-page;
+    break-inside: avoid;
   }
 
   ul {
@@ -126,11 +117,11 @@
   }
 
   footer {
+    padding-top: var(--page-margin);
+    position: running(footer);
+
     @media print {
-      bottom: calc((1 - var(--page-count)) * 100%);
-      position: absolute;
-      /* used to calculate dummyFooter height */
-      width: inherit;
+      padding-top: 0;
     }
   }
 }
@@ -158,6 +149,7 @@
 }
 
 @page {
-  margin: var(--page-margin);
-  size: var(--page-width) var(--page-height);
+  @bottom-center {
+    content: element(footer);
+  }
 }

--- a/assets/css/modern-hugo-resume.css
+++ b/assets/css/modern-hugo-resume.css
@@ -9,14 +9,27 @@
     margin-left: auto;
     margin-right: auto;
     max-width: var(--page-width);
+    /* css padding emulates PDF margins */
     padding: var(--page-margin);
+
+    @media not all and (min-width: theme("screens.sm")) {
+      padding: theme("margin.3");
+    }
+
+    @media print {
+      padding: 0;
+    }
   }
 
   main {
-    padding-bottom: var(--page-margin);
+    margin-bottom: var(--page-margin);
 
     & > *:first-child {
       margin-top: 0;
+    }
+
+    @media print {
+      margin-bottom: 0;
     }
   }
 
@@ -29,10 +42,8 @@
     --invert-body: theme("colors.gray.300");
     --invert-headings: theme("colors.white");
     --invert-link-hover: theme("colors.gray.100");
-  }
 
-  @media (prefers-color-scheme: dark) {
-    :root {
+    @media (prefers-color-scheme: dark) {
       --background: var(--invert-background);
       --body: var(--invert-body);
       --headings: var(--invert-headings);
@@ -42,11 +53,15 @@
 
   h1,
   h2,
-  h3 {
+  h3,
+  h4,
+  h5,
+  h6 {
     color: var(--headings);
     margin-bottom: theme("margin.4");
     margin-top: theme("margin.6");
     line-height: 1.25;
+    break-after: avoid-page;
   }
 
   h1 {
@@ -64,6 +79,9 @@
     font-weight: theme("fontWeight.semibold");
   }
 
+  h4,
+  h5,
+  h6,
   a,
   p,
   li {
@@ -75,6 +93,7 @@
   ul,
   ol {
     margin-bottom: theme("margin.4");
+    break-inside: avoid-page;
   }
 
   ul {
@@ -96,43 +115,22 @@
 
   a {
     text-decoration-line: underline;
-  }
 
-  a:hover {
-    color: var(--link-hover);
+    &:hover {
+      color: var(--link-hover);
+    }
+
+    @media print {
+      text-decoration-line: none;
+    }
   }
 
   footer {
-    width: theme("width.full");
-  }
-
-  @media print {
-    body {
-      padding: 0;
-    }
-
-    main {
-      padding-bottom: 0;
-    }
-
-    a {
-      text-decoration-line: none;
-    }
-
-    h2,
-    h3,
-    p {
-      break-after: avoid-page;
-    }
-
-    p,
-    ul {
-      break-inside: avoid-page;
-    }
-
-    footer {
-      position: absolute;
+    @media print {
       bottom: calc((1 - var(--page-count)) * 100%);
+      position: absolute;
+      /* used to calculate dummyFooter height */
+      width: inherit;
     }
   }
 }

--- a/assets/js/modern-hugo-resume.js
+++ b/assets/js/modern-hugo-resume.js
@@ -1,0 +1,51 @@
+async function initializePagedJS() {
+  await Promise.all([
+    import("https://unpkg.com/pagedjs@0.4.3/dist/paged.min.js"),
+    new Promise((resolve) => {
+      if (document.readyState !== "loading") resolve();
+      document.addEventListener("DOMContentLoaded", () => resolve());
+    }),
+  ]);
+
+  // Workaround for using custom properties with @page rules. For background on why this is an
+  // issue, see: https://stackoverflow.com/a/44738574
+  const referencePage = document.createElement("div");
+  referencePage.style.height = "var(--page-height)";
+  referencePage.style.width = "var(--page-width)";
+  referencePage.style.margin = "var(--page-margin)";
+  referencePage.style.position = "absolute";
+  referencePage.style.top = "-9999px";
+  document.body.appendChild(referencePage);
+  const referencePageStyles = window.getComputedStyle(referencePage);
+  const style = document.createElement("style");
+  style.innerHTML = `@page {
+    ${Object.entries({
+      size: `${referencePageStyles.width} ${referencePageStyles.height}`,
+      margin: referencePageStyles.margin,
+    }).reduce((acc, [key, value]) => `${acc}${key}: ${value};\n`, "")}
+  }`;
+  document.head.appendChild(style);
+  document.body.removeChild(referencePage);
+
+  const previewer = new PagedModule.Previewer();
+  await previewer.preview();
+}
+
+function showPrintPage() {
+  const url = new URL(window.location.href);
+  url.searchParams.set("print", "true");
+  history.pushState({}, "", url);
+  initializePagedJS();
+}
+
+if (new URL(window.location.href).searchParams.has("print")) {
+  initializePagedJS();
+} else {
+  window.onbeforeprint = showPrintPage;
+}
+
+window.onafterprint = () => {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("print");
+  window.location.href = url.href;
+};

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -101,7 +101,7 @@ Software Developer with 3 Years of Full Stack Web and Mobile Experience
 [![](svgs/brands/linkedin.svg)in/cjshearer](https://linkedin.com/in/cjshearer "My LinkedIn")
 [![](svgs/solid/house.svg)cjshearer.dev](https://cjshearer.dev "My Website")
 [![](svgs/solid/envelope.svg)cjshearer@live.com](mailto:cjshearer@live.com "My Email")
-{class="inline-svg flex flex-wrap gap-4 whitespace-nowrap mb-0"}
+{class="inline-svg flex flex-wrap justify-center gap-4 whitespace-nowrap mb-0"}
 
 </footer>
 </body>

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -23,7 +23,7 @@ Software Developer with 3 Years of Full Stack Web and Mobile Experience
 
 ### Software Developer – Full Stack, Krumware
 
-March 2021 to October 2023
+#### March 2021 to October 2023
 
 - Collaborated in cross-functional team following agile (scrum) methodologies
 - Improved time-to-market by up to 20% with project templates
@@ -34,7 +34,7 @@ March 2021 to October 2023
 - Led company transition to Golang, improving performance, type-safety, and DX
 - Promoted culture of continuous improvement, code reviews, and linting
 
-Project Highlights:
+##### Project Highlights:
 
 - Developed React app, React-Native app, Node servers for equipment manufacturer
   - Created Bluetooth abstraction with data anomaly filtering, connection recovery
@@ -51,7 +51,7 @@ Project Highlights:
 
 ### Research Assistant, AI and Systems Laboratory
 
-August 2020 to April 2021
+#### August 2020 to April 2021
 
 - Analyzed cross-platform performance behavior of deep-learning recommender system
 - Reproduced results from past research on highly configurable systems
@@ -59,7 +59,7 @@ August 2020 to April 2021
 
 ### Software Developer – Intern, Velocity
 
-June 2018 to August 2018
+#### June 2018 to August 2018
 
 - Created AWS storage primitive abstracting cloud complexity for high level orchestration
 - Developed storage optimization solution for Amazon Elastic Block Storage
@@ -68,7 +68,7 @@ June 2018 to August 2018
 
 ### BS Computer Science, University of South Carolina
 
-August 2017 to May 2021
+#### August 2017 to May 2021
 
 - Graduated _magna cum laude_ with a mathematics minor
 - Achieved [Outstanding Senior Award](https://sc.edu/about/offices_and_divisions/leadership_and_service_center/awards_and_recognition/senior-awards/index.php) and the [Palmetto Fellows Scholarship](https://sc.edu/about/offices_and_divisions/financial_aid/scholarships/scholarships_for_sc_residents/palmetto_fellows/index.php)
@@ -101,7 +101,7 @@ August 2017 to May 2021
 [![](svgs/brands/linkedin.svg)in/cjshearer](https://linkedin.com/in/cjshearer "My LinkedIn")
 [![](svgs/solid/house.svg)cjshearer.dev](https://cjshearer.dev "My Website")
 [![](svgs/solid/envelope.svg)cjshearer@live.com](mailto:cjshearer@live.com "My Email")
-{class="inline-svg flex flex-wrap justify-center gap-4 whitespace-nowrap mb-0"}
+{class="inline-svg flex flex-wrap gap-4 whitespace-nowrap mb-0"}
 
 </footer>
 </body>

--- a/layouts/modern-hugo-resume/index.html
+++ b/layouts/modern-hugo-resume/index.html
@@ -50,66 +50,12 @@
         <style>{{- $style.Content | safeCSS }}</style>
       {{- end -}}
     {{- end -}}
+    {{- with resources.Get "js/modern-hugo-resume.js" -}}
+      {{- $defines := dict "import.meta.env.MODE" (printf `"%s"` hugo.Environment) -}}
+      {{- $opts := dict "format" "esm" "defines" $defines -}}
+      {{- $js := . | js.Build $opts -}}
+      <script type="module">{{- $js.Content | safeJS -}}</script>
+    {{- end -}}
   </head>
   {{ .Content }}
-  <script defer>
-    (() => {
-      const main = document.getElementsByTagName("main")?.[0];
-      const footer = document.getElementsByTagName("footer")?.[0];
-    
-      if (!(footer && main)) return;
-    
-      // referencePage helps calculate which page to place the footer on when printing
-      const referencePage = document.createElement("div");
-      referencePage.style.height = "var(--page-height)";
-      // css padding emulates PDF margins
-      referencePage.style.padding = "var(--page-margin)";
-      referencePage.style.position = "absolute";
-      referencePage.style.top = "-9999px";
-    
-      document.body.appendChild(referencePage);
-      const referencePageStyles = window.getComputedStyle(referencePage);
-      const effectivePageHeight =
-        Number.parseFloat(referencePageStyles.height) -
-        Number.parseFloat(referencePageStyles.paddingTop) -
-        Number.parseFloat(referencePageStyles.paddingBottom);
-      document.body.removeChild(referencePage);
-    
-      // dummyFooter prevents the real footer from overlapping the main document
-      const dummyFooter = document.createElement("div");
-    
-      onbeforeprint = () => {
-        // temporarily enable "@media print" to reliably get the height of the elements
-        for (style of document.getElementsByTagName("style")) {
-          style.innerText = 
-            style.innerText.replace(/@media print {/gi, "@media screen { /*print*/");
-        }
-    
-        // temporarily fix width and padding to reliably get the height of elements
-        document.body.style.width = "var(--page-width)";
-        document.body.style.padding = "var(--page-margin)";
-    
-        dummyFooter.style.height = getComputedStyle(footer).height;
-        const printedDocumentHeight = document.body.scrollHeight;
-    
-        // reset document styling
-        document.body.style.width = "";
-        document.body.style.padding = "";
-        for (style of document.getElementsByTagName("style")) {
-          style.innerText = style.innerText.replace(
-            /@media screen { \/\*print\*\//gi,
-            "@media print {",
-          );
-        }
-    
-        document.documentElement.style.setProperty(
-          "--page-count",
-          Math.ceil(printedDocumentHeight / effectivePageHeight),
-        );
-    
-        main.appendChild(dummyFooter);
-      };
-      onafterprint = () => main.removeChild(dummyFooter);
-    })();
-  </script>
 </html>

--- a/layouts/modern-hugo-resume/index.html
+++ b/layouts/modern-hugo-resume/index.html
@@ -68,26 +68,34 @@
       referencePage.style.margin = "var(--page-margin)";
       referencePage.style.position = "absolute";
       referencePage.style.top = "-9999px";
+
       document.body.appendChild(referencePage);
+      const referencePageStyles = window.getComputedStyle(referencePage);
+      const effectivePageHeight =
+      Number.parseFloat(referencePageStyles.height) -
+      Number.parseFloat(referencePageStyles.marginTop) -
+      Number.parseFloat(referencePageStyles.marginBottom);
+      document.body.removeChild(referencePage);
     
       // dummyFooter prevents the real footer from overlapping the main document
       const dummyFooter = document.createElement("div");
-      dummyFooter.style.height = getComputedStyle(footer).height;
-    
-      const referencePageStyles = window.getComputedStyle(referencePage);
-      const documentHeight =
-        document.body.scrollHeight - 2 * Number.parseFloat(dummyFooter.style.height);
-      const effectivePageHeight =
-        Number.parseFloat(referencePageStyles.height) -
-        Number.parseFloat(referencePageStyles.marginTop) -
-        Number.parseFloat(referencePageStyles.marginBottom);
-    
-      document.documentElement.style.setProperty(
-        "--page-count",
-        Math.ceil(documentHeight / effectivePageHeight),
-      );
-    
-      onbeforeprint = () => main.appendChild(dummyFooter);
+
+      onbeforeprint = () => {
+        main.appendChild(dummyFooter);
+
+        // the page width must be fixed to reliably get the height of printed elements on the page
+        const originalDocumentWidth = document.body.style.width;
+        document.body.style.width = 'max-content';
+        dummyFooter.style.height = getComputedStyle(footer).height;
+        const printedDocumentHeight =
+          document.body.scrollHeight - Number.parseFloat(dummyFooter.style.height);
+        document.body.style.width = originalDocumentWidth;
+        
+        document.documentElement.style.setProperty(
+          "--page-count",
+          Math.ceil(printedDocumentHeight / effectivePageHeight),
+        );
+      };
       onafterprint = () => main.removeChild(dummyFooter);
     })();    
   </script>

--- a/layouts/modern-hugo-resume/index.html
+++ b/layouts/modern-hugo-resume/index.html
@@ -38,19 +38,16 @@
 
     {{- with (templates.Defer (dict "key" "global")) -}}
       {{- with resources.Get "css/modern-hugo-resume.css" -}}
-        {{ $opts := dict
+        {{ 
+          $opts := dict
           "inlineImports" true
           "optimize" hugo.IsProduction
         }}
-        {{- with . | css.TailwindCSS $opts -}}
-          {{- if hugo.IsDevelopment -}}
-            <link rel="stylesheet" href="{{ .RelPermalink }}" />
-          {{- else -}}
-            {{- with . | minify | fingerprint -}}
-              <style>{{- .Content | safeCSS }}</style>
-            {{- end -}}
-          {{- end -}}
+        {{- $style := . | css.TailwindCSS $opts -}}
+        {{- if hugo.IsProduction -}}
+          {{- $style = $style | minify | fingerprint -}}
         {{- end -}}
+        <style>{{- $style.Content | safeCSS }}</style>
       {{- end -}}
     {{- end -}}
   </head>
@@ -65,38 +62,54 @@
       // referencePage helps calculate which page to place the footer on when printing
       const referencePage = document.createElement("div");
       referencePage.style.height = "var(--page-height)";
-      referencePage.style.margin = "var(--page-margin)";
+      // css padding emulates PDF margins
+      referencePage.style.padding = "var(--page-margin)";
       referencePage.style.position = "absolute";
       referencePage.style.top = "-9999px";
-
+    
       document.body.appendChild(referencePage);
       const referencePageStyles = window.getComputedStyle(referencePage);
       const effectivePageHeight =
-      Number.parseFloat(referencePageStyles.height) -
-      Number.parseFloat(referencePageStyles.marginTop) -
-      Number.parseFloat(referencePageStyles.marginBottom);
+        Number.parseFloat(referencePageStyles.height) -
+        Number.parseFloat(referencePageStyles.paddingTop) -
+        Number.parseFloat(referencePageStyles.paddingBottom);
       document.body.removeChild(referencePage);
     
       // dummyFooter prevents the real footer from overlapping the main document
       const dummyFooter = document.createElement("div");
-
+    
       onbeforeprint = () => {
-        main.appendChild(dummyFooter);
-
-        // the page width must be fixed to reliably get the height of printed elements on the page
-        const originalDocumentWidth = document.body.style.width;
-        document.body.style.width = 'max-content';
+        // temporarily enable "@media print" to reliably get the height of the elements
+        for (style of document.getElementsByTagName("style")) {
+          style.innerText = 
+            style.innerText.replace(/@media print {/gi, "@media screen { /*print*/");
+        }
+    
+        // temporarily fix width and padding to reliably get the height of elements
+        document.body.style.width = "var(--page-width)";
+        document.body.style.padding = "var(--page-margin)";
+    
         dummyFooter.style.height = getComputedStyle(footer).height;
-        const printedDocumentHeight =
-          document.body.scrollHeight - Number.parseFloat(dummyFooter.style.height);
-        document.body.style.width = originalDocumentWidth;
-        
+        const printedDocumentHeight = document.body.scrollHeight;
+    
+        // reset document styling
+        document.body.style.width = "";
+        document.body.style.padding = "";
+        for (style of document.getElementsByTagName("style")) {
+          style.innerText = style.innerText.replace(
+            /@media screen { \/\*print\*\//gi,
+            "@media print {",
+          );
+        }
+    
         document.documentElement.style.setProperty(
           "--page-count",
           Math.ceil(printedDocumentHeight / effectivePageHeight),
         );
+    
+        main.appendChild(dummyFooter);
       };
       onafterprint = () => main.removeChild(dummyFooter);
-    })();    
+    })();
   </script>
 </html>


### PR DESCRIPTION
My attempt to automatically calculate the number of pages in the layout failed to account for page breaks that created additional spacing. This is a difficult problem, so I have replaced my naive approach with paged.js, which reconstructs the page at runtime. I have integrated it such that attempts to print the original resume will navigate the same page, but with a `print=true` query param, which will load and run paged.js.