### PR TITLE
fix: improve paged.js load time for print

### DIFF
--- a/assets/js/modern-hugo-resume.js
+++ b/assets/js/modern-hugo-resume.js
@@ -1,11 +1,10 @@
+import("https://unpkg.com/pagedjs@0.4.3/dist/paged.min.js");
+
 async function initializePagedJS() {
-  await Promise.all([
-    import("https://unpkg.com/pagedjs@0.4.3/dist/paged.min.js"),
-    new Promise((resolve) => {
-      if (document.readyState !== "loading") resolve();
-      document.addEventListener("DOMContentLoaded", () => resolve());
-    }),
-  ]);
+  await new Promise((resolve) => {
+    if (document.readyState !== "loading") resolve();
+    document.addEventListener("DOMContentLoaded", () => resolve());
+  });
 
   // Workaround for using custom properties with @page rules. For background on why this is an
   // issue, see: https://stackoverflow.com/a/44738574
@@ -31,11 +30,11 @@ async function initializePagedJS() {
   await previewer.preview();
 }
 
-function showPrintPage() {
+async function showPrintPage() {
   const url = new URL(window.location.href);
   url.searchParams.set("print", "true");
   history.pushState({}, "", url);
-  initializePagedJS();
+  await initializePagedJS();
 }
 
 if (new URL(window.location.href).searchParams.has("print")) {


### PR DESCRIPTION
Waiting to dynamically load paged.js `onbeforeprint` will cause users on slow connections to occasionally get a print dialog showing the document's web format, instead of the print format. As we cannot make `onbeforeprint` wait until paged.js loads, we now load it as soon as the page's javascript is processed.